### PR TITLE
chore: rebase claude/rebase-to-main-FHbiy onto latest main

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
-# [Choice] Debian / Ubuntu version: debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
-# See https://github.com/microsoft/vscode-dev-containers/tree/master/containers/debian
+# [Choice] Debian / Ubuntu version: debian-12, debian-11, ubuntu-24.04, ubuntu-22.04
+# See https://github.com/devcontainers/images/tree/main/src/base-debian
+# and https://github.com/devcontainers/images/tree/main/src/base-ubuntu
 ARG VARIANT=debian-12
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 
@@ -48,7 +49,7 @@ RUN /bin/bash /tmp/node.sh 24.x
 COPY scripts/docker-client.sh /tmp/
 RUN /bin/bash /tmp/docker-client.sh
 
-#Add user to docker group
+# Add user to docker group
 RUN sudo groupadd docker && sudo usermod -aG docker $USERNAME && newgrp docker
 
 # act

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
-// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.117.1/containers/go
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json
+// or this file's README at: https://github.com/devcontainers/images/tree/main/src/go
 {
 	"name": "devcontainers-ci",
 	"dockerFile": "Dockerfile",


### PR DESCRIPTION
## Summary
- Rebased `claude/rebase-to-main-FHbiy` onto the latest `origin/main` to bring in upstream changes (Node 24 update, Debian 12 base image refresh, Go 1.25 test update, AzDO publish input, etc.).
- The branch carried a single commit (`chore: update devcontainer comments`), which was replayed cleanly on top of main without conflicts.

## Test plan
- [ ] Confirm CI passes on the rebased branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TA5oekmAAamHCdfFBMv9bz)_

## Summary by Sourcery

Refresh devcontainer configuration metadata to align with newer Debian/Ubuntu base images and documentation links.

Enhancements:
- Update devcontainer Dockerfile comments to reference current Debian/Ubuntu version choices and the new devcontainers base image repositories.
- Tidy Dockerfile comment formatting for consistency.